### PR TITLE
Update settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -50,6 +50,7 @@ rulesets:
     rules:
       - type: pull_request
         parameters:
+          allowed_merge_methods: ["merge"]
           dismiss_stale_reviews_on_push: true
           require_code_owner_review: false
           require_last_push_approval: true
@@ -69,6 +70,7 @@ rulesets:
     rules:
       - type: pull_request
         parameters:
+          allowed_merge_methods: ["merge"]
           dismiss_stale_reviews_on_push: true
           require_code_owner_review: false
           require_last_push_approval: true
@@ -88,6 +90,7 @@ rulesets:
     rules:
       - type: pull_request
         parameters:
+          allowed_merge_methods: ["squash"]
           dismiss_stale_reviews_on_push: true
           require_code_owner_review: false
           require_last_push_approval: true
@@ -95,4 +98,3 @@ rulesets:
           required_review_thread_resolution: false
       - type: non_fast_forward
       - type: deletion
-      - type: required_linear_history


### PR DESCRIPTION

## Description

Merge request type per branch:

 - E2E - squash
 - UAT - merge
 - main - merge

Also removing the linear history setting since it shouldn't be necessary and one less thing to remember on the off chance rules need to be overridden. Leaving the repo wide settings of allowing merges and squashes.

## Reproduction

<!---
If this PR is for a bug fix, explain how to reproduce the bug
-->
